### PR TITLE
fix: can't click continue button on register

### DIFF
--- a/frontend/src/views/Quiz.vue
+++ b/frontend/src/views/Quiz.vue
@@ -153,6 +153,16 @@
 import dishes from "@/assets/quiz_dishes/dishes.json";
 import config from "@/config.js";
 import { mapActions } from "vuex";
+
+// VueJS reactivity (e.g the recomputed values) only observe
+// the existing set of keys. In this case, without adding
+// this "rating" key to the initial object, ratings_incomplete
+// will always return false and won't let the user continue.
+const dishesWithNullRating = dishes.map((dish) => {
+  dish.rating = null;
+  return dish;
+});
+
 export default {
   name: "Quiz",
   data: () => ({
@@ -212,6 +222,7 @@ export default {
     search: null,
     selected_allergies: [],
     selected_additives: [],
+    /*
     dishes: [
       {
         name: "Burger with Salad",
@@ -272,8 +283,8 @@ export default {
           false,
         ],
       },
-    ],
-    dishes: dishes,
+    ],*/
+    dishes: dishesWithNullRating,
     form: {
       email: "",
       password: "",


### PR DESCRIPTION
The continue button is unclickable because the "rating" key is not part of the initial state, which breaks Vue JS reactivity.

![image](https://user-images.githubusercontent.com/117648398/205746247-303c6241-db0c-4d57-a1ed-87d53309aa8f.png)