### PR TITLE
fix: use visibility to hide logout & balance

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -169,6 +169,6 @@ $btnColor: var(--v-btnColor-base);
 }
 
 .invisible {
-    visibility: hidden !important;
-  }
+  visibility: hidden !important;
+}
 </style>


### PR DESCRIPTION
When logging in, the nav bar gets resized, instead just keep the same size and hide the logout & balance elements.
Fixes a tiny bug where the navigation line indicator did not shift along with the resize.