### PR TITLE
:bug: minor fix if there are no suggested dishes

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -19,7 +19,7 @@ div
             v-tabs-slider(color="primary")
 
           v-tabs-items.align-center.justify-center.d-flex.py-2(v-model="tab") 
-            h3(v-show="items[Object.keys(items)[currentTab]] == []") There are no recommended dishes today {{ items[Object.keys(items)[currentTab]] }}
+            h3(v-show="items[Object.keys(items)[currentTab]].length == 0") There are no recommended dishes today. The mensa might be closed.
             template(v-for="(array, key) in items")
               template(v-if="currentTab === Object.keys(items).indexOf(key)")
                 v-row.justify-center
@@ -297,6 +297,7 @@ export default {
     },
   },
   mounted() {
+    this.getOneRecommendation();
     this.getRecommendations();
     this.getUserData();
   },


### PR DESCRIPTION
In case the mensa is closed, no dishes can be recommended. In this case there should be a message indicating that for the user instead of a white screen. Before, the condition checking for this event was faulty.